### PR TITLE
Foxglove websocket: Use system time if server does not publish time messages

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -305,7 +305,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
       const time = fromNanoSec(timestamp);
       if (this._clockTime != undefined && isLessThan(time, this._clockTime)) {
-        ++this._lastSeekTime;
+        this._lastSeekTime = time.sec;
         this._parsedMessages = [];
       }
 
@@ -491,7 +491,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     throw new Error("Service calls are not supported by the Foxglove WebSocket connection");
   }
 
-  public setGlobalVariables(): void {}
+  public setGlobalVariables(): void { }
 
   private _getCurrentTime(): Time {
     return this._serverPublishesTime ? this._clockTime ?? ZERO_TIME : fromMillis(Date.now());

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from "uuid";
 import { debouncePromise } from "@foxglove/den/async";
 import Log from "@foxglove/log";
 import { parseChannel, ParsedChannel } from "@foxglove/mcap-support";
-import { fromNanoSec, isGreaterThan, isLessThan, Time } from "@foxglove/rostime";
+import { fromMillis, fromNanoSec, isGreaterThan, isLessThan, Time } from "@foxglove/rostime";
 import PlayerProblemManager from "@foxglove/studio-base/players/PlayerProblemManager";
 import {
   AdvertiseOptions,
@@ -63,8 +63,6 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
   /** Earliest time seen */
   private _startTime?: Time;
-  /** Most recently-seen time */
-  private _currentTime?: Time;
   /** Latest time seen */
   private _endTime?: Time;
   /* The most recent published time, if available */
@@ -131,7 +129,6 @@ export default class FoxgloveWebSocketPlayer implements Player {
       log.info("Connection closed:", event);
       this._presence = PlayerPresence.RECONNECTING;
       this._startTime = undefined;
-      this._currentTime = undefined;
       this._endTime = undefined;
       this._clockTime = undefined;
       this._serverPublishesTime = false;
@@ -249,7 +246,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._emitState();
     });
 
-    client.on("message", ({ subscriptionId, timestamp, data }) => {
+    client.on("message", ({ subscriptionId, data }) => {
       if (!this._hasReceivedMessage) {
         this._hasReceivedMessage = true;
         this._metricsCollector.recordTimeToFirstMsgs();
@@ -268,26 +265,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
       }
 
       try {
-        const receiveTime = this._serverPublishesTime
-          ? this._clockTime ?? ZERO_TIME
-          : fromNanoSec(timestamp);
+        const receiveTime = this._getCurrentTime();
         const topic = chanInfo.channel.topic;
-        // If time goes backwards, increment lastSeekTime and discard unemitted messages from before
-        // the discontinuity. This prevents us from queueing an unbounded number of messages when
-        // servers loop over the same recorded data multiple times. However, for now the queue can
-        // still grow unboundedly in a live system if the listener is not processing messages (such
-        // as when the app is hidden/backgrounded).
-        if (this._currentTime && isLessThan(receiveTime, this._currentTime)) {
-          ++this._lastSeekTime;
-          this._parsedMessages = [];
-        }
-        this._currentTime = receiveTime;
-        if (!this._startTime || isLessThan(receiveTime, this._startTime)) {
-          this._startTime = receiveTime;
-        }
-        if (!this._endTime || isGreaterThan(receiveTime, this._endTime)) {
-          this._endTime = receiveTime;
-        }
         this._parsedMessages.push({
           topic,
           receiveTime,
@@ -383,6 +362,14 @@ export default class FoxgloveWebSocketPlayer implements Player {
       });
     }
 
+    const currentTime = this._getCurrentTime();
+    if (!this._startTime || isLessThan(currentTime, this._startTime)) {
+      this._startTime = currentTime;
+    }
+    if (!this._endTime || isGreaterThan(currentTime, this._endTime)) {
+      this._endTime = currentTime;
+    }
+
     const messages = this._parsedMessages;
     this._parsedMessages = [];
     return this._listener({
@@ -401,9 +388,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
       activeData: {
         messages,
         totalBytesReceived: this._receivedBytes,
-        startTime: this._startTime ?? ZERO_TIME,
-        endTime: this._endTime ?? ZERO_TIME,
-        currentTime: this._currentTime ?? ZERO_TIME,
+        startTime: this._startTime,
+        endTime: this._endTime,
+        currentTime,
         isPlaying: true,
         speed: 1,
         lastSeekTime: this._lastSeekTime,
@@ -505,4 +492,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
   }
 
   public setGlobalVariables(): void {}
+
+  private _getCurrentTime(): Time {
+    return this._serverPublishesTime ? this._clockTime ?? ZERO_TIME : fromMillis(Date.now());
+  }
 }


### PR DESCRIPTION
**User-Facing Changes**
- Foxglove websocket: Use system time if server does not publish time messages

**Description**
This PR is based on #5008 and only to be merged after 1-2 releases after #5008 got in. It is the second part of the migraiton strategy proposed in https://github.com/foxglove/studio/pull/4984#issuecomment-1360366496

From #5008:

> Since https://github.com/foxglove/ws-protocol/pull/299, the foxglove websocket server may send time messages to clients. If this is the case, Studio will use the server-published time as the message receive timestamp instead of the actual message receive time. This helps in preventing undesired “clearing” issues caused by messages being out of order across channels. The player behavior remains the same if the server does not provide time information to clients.

This PR changes the behavior in the following way:
- The system time is used if the server does not provide time information to clients


Fixes foxglove/community#239
Fixes #4917
Fixes #4908